### PR TITLE
Upgrade node, manet, phantomjs and slimerjs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,10 @@ EXPOSE 8891
 
 RUN apt-get update && \
     apt-get -y install curl && \
-    curl -sL https://deb.nodesource.com/setup | sudo bash - && \
+    curl -sL https://deb.nodesource.com/setup_4.x | sudo bash - && \
     apt-get -y install nodejs build-essential xvfb libfontconfig1 && \
-    npm install -g slimerjs && \
-    npm install -g phantomjs && \
-    npm install -g manet
+    npm install -g slimerjs@0.9.6-2 && \
+    npm install -g phantomjs@1.9.19 && \
+    npm install -g manet@0.4.8
 
 ENTRYPOINT ["/usr/bin/manet"]


### PR DESCRIPTION
node@v4.2.4 (was v0.10.38)
manet@0.4.8 (was 0.3.8)
phantomjs@1.9.19 (was 1.9.17)
slimerjs@0.9.6-2 (was 0.9.5)

Upgraded because we needed to capture a long URL that exceeded the file system's max length. It was fixed in https://github.com/vbauer/manet/commit/d911c51667af44d7fc8832633a90e9e2fde45e54
